### PR TITLE
OPNFLWPLUG-936 table 213 has high priority drop rule

### DIFF
--- a/openflowjava/openflow-protocol-api/src/main/java/org/opendaylight/openflowjava/protocol/api/extensibility/SerializerRegistry.java
+++ b/openflowjava/openflow-protocol-api/src/main/java/org/opendaylight/openflowjava/protocol/api/extensibility/SerializerRegistry.java
@@ -29,7 +29,7 @@ public interface SerializerRegistry {
      * @param msgTypeKey lookup key
      * @return serializer or NullPointerException if no serializer was found
      */
-    <K, S extends OFGeneralSerializer> S getSerializer(MessageTypeKey<K> msgTypeKey);
+    <K, S extends OFGeneralSerializer> S getSerializer(MessageTypeKey<K> msgTypeKey) throws IllegalStateException;
 
     /**
      * Registers a serializer.

--- a/openflowjava/openflow-protocol-impl/src/main/java/org/opendaylight/openflowjava/protocol/impl/serialization/factories/FlowModInputMessageFactory.java
+++ b/openflowjava/openflow-protocol-impl/src/main/java/org/opendaylight/openflowjava/protocol/impl/serialization/factories/FlowModInputMessageFactory.java
@@ -57,9 +57,15 @@ public class FlowModInputMessageFactory implements OFSerializer<FlowMod>, Serial
         outBuffer.writeInt(message.getOutGroup().intValue());
         outBuffer.writeShort(createFlowModFlagsBitmask(message.getFlags()));
         outBuffer.writeZero(PADDING_IN_FLOW_MOD_MESSAGE);
-        registry.<Match, OFSerializer<Match>>getSerializer(new MessageTypeKey<>(message.getVersion(), Match.class))
-            .serialize(message.getMatch(), outBuffer);
-        ListSerializer.serializeList(message.getInstruction(), INSTRUCTION_KEY_MAKER, registry, outBuffer);
+        try {
+            registry.<Match, OFSerializer<Match>>getSerializer(new MessageTypeKey<>(message.getVersion(), Match.class))
+                    .serialize(message.getMatch(), outBuffer);
+            ListSerializer.serializeList(message.getInstruction(), INSTRUCTION_KEY_MAKER, registry, outBuffer);
+
+        } catch (final IllegalStateException e) {
+            outBuffer.clear();
+            return;
+        }
         ByteBufUtils.updateOFHeaderLength(outBuffer, index);
     }
 

--- a/openflowplugin-impl/src/main/java/org/opendaylight/openflowplugin/impl/protocol/serialization/match/MatchSerializer.java
+++ b/openflowplugin-impl/src/main/java/org/opendaylight/openflowplugin/impl/protocol/serialization/match/MatchSerializer.java
@@ -119,7 +119,7 @@ public class MatchSerializer implements OFSerializer<Match>, HeaderSerializer<Ma
                         LOG.warn("Serializer for match entry {} for version {} not found.",
                                 extension.getExtension().implementedInterface(),
                                 OFConstants.OFP_VERSION_1_3);
-                        return null;
+                        throw new IllegalStateException("serializeExtensionList get Serializer for match entry fail");
                     });
         });
     }

--- a/openflowplugin-impl/src/main/java/org/opendaylight/openflowplugin/impl/protocol/serialization/messages/FlowMessageSerializer.java
+++ b/openflowplugin-impl/src/main/java/org/opendaylight/openflowplugin/impl/protocol/serialization/messages/FlowMessageSerializer.java
@@ -110,24 +110,28 @@ public class FlowMessageSerializer extends AbstractMessageSerializer<FlowMessage
      * @param outBuffer output buffer
      */
     private void writeFlow(final FlowMessage message, final ByteBuf outBuffer) {
-        final int index = outBuffer.writerIndex();
-        super.serialize(message, outBuffer);
-        outBuffer.writeLong(MoreObjects.firstNonNull(message.getCookie(), DEFAULT_COOKIE).getValue().longValue());
-        outBuffer.writeLong(MoreObjects.firstNonNull(message.getCookieMask(), DEFAULT_COOKIE_MASK).getValue()
-                .longValue());
-        outBuffer.writeByte(MoreObjects.firstNonNull(message.getTableId(), DEFAULT_TABLE_ID));
-        outBuffer.writeByte(message.getCommand().getIntValue());
-        outBuffer.writeShort(MoreObjects.firstNonNull(message.getIdleTimeout(), DEFAULT_IDLE_TIMEOUT));
-        outBuffer.writeShort(MoreObjects.firstNonNull(message.getHardTimeout(), DEFAULT_HARD_TIMEOUT));
-        outBuffer.writeShort(MoreObjects.firstNonNull(message.getPriority(), DEFAULT_PRIORITY));
-        outBuffer.writeInt(MoreObjects.firstNonNull(message.getBufferId(), DEFAULT_BUFFER_ID).intValue());
-        outBuffer.writeInt(MoreObjects.firstNonNull(message.getOutPort(), DEFAULT_OUT_PORT).intValue());
-        outBuffer.writeInt(MoreObjects.firstNonNull(message.getOutGroup(), DEFAULT_OUT_GROUP).intValue());
-        outBuffer.writeShort(createFlowModFlagsBitmask(MoreObjects.firstNonNull(message.getFlags(), DEFAULT_FLAGS)));
-        outBuffer.writeZero(PADDING_IN_FLOW_MOD_MESSAGE);
-        writeMatch(message, outBuffer);
-        writeInstructions(message, outBuffer);
-        outBuffer.setShort(index + 2, outBuffer.writerIndex() - index);
+        try {
+            final int index = outBuffer.writerIndex();
+            super.serialize(message, outBuffer);
+            outBuffer.writeLong(MoreObjects.firstNonNull(message.getCookie(), DEFAULT_COOKIE).getValue().longValue());
+            outBuffer.writeLong(MoreObjects.firstNonNull(message.getCookieMask(), DEFAULT_COOKIE_MASK).getValue()
+                    .longValue());
+            outBuffer.writeByte(MoreObjects.firstNonNull(message.getTableId(), DEFAULT_TABLE_ID));
+            outBuffer.writeByte(message.getCommand().getIntValue());
+            outBuffer.writeShort(MoreObjects.firstNonNull(message.getIdleTimeout(), DEFAULT_IDLE_TIMEOUT));
+            outBuffer.writeShort(MoreObjects.firstNonNull(message.getHardTimeout(), DEFAULT_HARD_TIMEOUT));
+            outBuffer.writeShort(MoreObjects.firstNonNull(message.getPriority(), DEFAULT_PRIORITY));
+            outBuffer.writeInt(MoreObjects.firstNonNull(message.getBufferId(), DEFAULT_BUFFER_ID).intValue());
+            outBuffer.writeInt(MoreObjects.firstNonNull(message.getOutPort(), DEFAULT_OUT_PORT).intValue());
+            outBuffer.writeInt(MoreObjects.firstNonNull(message.getOutGroup(), DEFAULT_OUT_GROUP).intValue());
+            outBuffer.writeShort(createFlowModFlagsBitmask(MoreObjects.firstNonNull(message.getFlags(), DEFAULT_FLAGS)));
+            outBuffer.writeZero(PADDING_IN_FLOW_MOD_MESSAGE);
+            writeMatch(message, outBuffer);
+            writeInstructions(message, outBuffer);
+            outBuffer.setShort(index + 2, outBuffer.writerIndex() - index);
+        } catch (IllegalStateException e) {
+            outBuffer.clear();
+        }
     }
 
     /**

--- a/openflowplugin-impl/src/main/java/org/opendaylight/openflowplugin/impl/protocol/serialization/util/ActionUtil.java
+++ b/openflowplugin-impl/src/main/java/org/opendaylight/openflowplugin/impl/protocol/serialization/util/ActionUtil.java
@@ -47,32 +47,30 @@ public final class ActionUtil {
      */
     @SuppressWarnings("unchecked")
     public static void writeAction(Action action, short version, SerializerRegistry registry, ByteBuf outBuffer) {
-        try {
-            Optional.ofNullable(OFSessionUtil.getExtensionConvertorProvider())
-                    .flatMap(provider ->
-                            (action instanceof GeneralExtensionGrouping
-                                    ? convertExtensionGrouping(provider, (GeneralExtensionGrouping)action, version)
-                                    : convertGenericAction(provider, action, version))
-                                    .map(ofjAction -> {
-                                        final OFSerializer<org.opendaylight.yang.gen.v1.urn.opendaylight.openflow.common
-                                                .action.rev150203.actions.grouping.Action> serializer = registry
-                                                .getSerializer(TypeKeyMakerFactory.createActionKeyMaker(version)
-                                                        .make(ofjAction));
 
-                                        serializer.serialize(ofjAction, outBuffer);
-                                        return action;
-                                    })
-                    ).orElseGet(() -> {
-                        final OFSerializer<Action> serializer = registry.getSerializer(
-                                new MessageTypeKey<>(
-                                        version, (Class<? extends Action>) action.implementedInterface()));
+        Optional.ofNullable(OFSessionUtil.getExtensionConvertorProvider())
+                .flatMap(provider ->
+                        (action instanceof GeneralExtensionGrouping
+                                ? convertExtensionGrouping(provider, (GeneralExtensionGrouping)action, version)
+                                : convertGenericAction(provider, action, version))
+                                .map(ofjAction -> {
+                                    final OFSerializer<org.opendaylight.yang.gen.v1.urn.opendaylight.openflow.common
+                                            .action.rev150203.actions.grouping.Action> serializer = registry
+                                            .getSerializer(TypeKeyMakerFactory.createActionKeyMaker(version)
+                                                    .make(ofjAction));
 
-                        serializer.serialize(action, outBuffer);
-                        return action;
-                    });
-        } catch (final IllegalStateException | ClassCastException e) {
-            LOG.warn("Serializer for action {} for version {} not found.", action.implementedInterface(), version);
-        }
+                                    serializer.serialize(ofjAction, outBuffer);
+                                    return action;
+                                })
+                ).orElseGet(() -> {
+                    final OFSerializer<Action> serializer = registry.getSerializer(
+                            new MessageTypeKey<>(
+                                    version, (Class<? extends Action>) action.implementedInterface()));
+
+                    serializer.serialize(action, outBuffer);
+                    return action;
+                });
+
     }
 
     /**
@@ -86,34 +84,30 @@ public final class ActionUtil {
      */
     @SuppressWarnings("unchecked")
     public static void writeActionHeader(Action action, short version, SerializerRegistry registry, ByteBuf outBuffer) {
-        try {
-            Optional.ofNullable(OFSessionUtil.getExtensionConvertorProvider())
-                    .flatMap(provider ->
-                            (action instanceof GeneralExtensionGrouping
-                                    ? convertExtensionGrouping(provider, (GeneralExtensionGrouping)action, version)
-                                    : convertGenericAction(provider, action, version))
-                                    .map(ofjAction -> {
-                                        final HeaderSerializer<org.opendaylight.yang.gen.v1.urn.opendaylight.openflow
-                                                .common
-                                                .action.rev150203.actions.grouping.Action> serializer = registry
-                                                .getSerializer(TypeKeyMakerFactory.createActionKeyMaker(version)
-                                                        .make(ofjAction));
+        Optional.ofNullable(OFSessionUtil.getExtensionConvertorProvider())
+                .flatMap(provider ->
+                        (action instanceof GeneralExtensionGrouping
+                                ? convertExtensionGrouping(provider, (GeneralExtensionGrouping)action, version)
+                                : convertGenericAction(provider, action, version))
+                                .map(ofjAction -> {
+                                    final HeaderSerializer<org.opendaylight.yang.gen.v1.urn.opendaylight.openflow
+                                            .common
+                                            .action.rev150203.actions.grouping.Action> serializer = registry
+                                            .getSerializer(TypeKeyMakerFactory.createActionKeyMaker(version)
+                                                    .make(ofjAction));
 
-                                        serializer.serializeHeader(ofjAction, outBuffer);
-                                        return action;
-                                    })
-                    ).orElseGet(() -> {
-                        final HeaderSerializer<Action> serializer = registry.getSerializer(
-                                new MessageTypeKey<>(
-                                        version, (Class<? extends Action>) action.implementedInterface()));
+                                    serializer.serializeHeader(ofjAction, outBuffer);
+                                    return action;
+                                })
+                ).orElseGet(() -> {
+                    final HeaderSerializer<Action> serializer = registry.getSerializer(
+                            new MessageTypeKey<>(
+                                    version, (Class<? extends Action>) action.implementedInterface()));
 
-                        serializer.serializeHeader(action, outBuffer);
-                        return action;
-                    });
-        } catch (final IllegalStateException | ClassCastException e) {
-            LOG.warn("Header Serializer for action {} for version {} not found.", action.implementedInterface(),
-                    version);
-        }
+                    serializer.serializeHeader(action, outBuffer);
+                    return action;
+                });
+
     }
 
     /**


### PR DESCRIPTION
If the odl is closed when the flow table is delivered to openvswitch, the flow table serializatio maybe fail, and then  the error flow table will be  sented to the openvswitch.
The modification method is to clear the buffer that needs to be serialized if the serialization fails in the flow table, and avoid sending the error flow table to the openvswitch.
This modification method has been verified in the commercial deployment environmentt and is feasible.

We are Inspur Cisco R&D Team, I hope that you can pass the code  review. 
Best wishes!!